### PR TITLE
Add check update scripts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: '20.x'
-                  registry-url: 'https://registry.npmjs.org'
+                  registry-url: https://npm.pkg.github.com/
 
             - run: npm ci
             - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
             "version": "0.1.2",
             "license": "MIT",
             "dependencies": {
-                "@nextui-org/button": "^2.0.37",
-                "@nextui-org/card": "^2.0.33",
-                "lucide-react": "^0.439.0"
+                "@nextui-org/button": "^2.0.38",
+                "@nextui-org/card": "^2.0.34",
+                "lucide-react": "^0.441.0"
             },
             "devDependencies": {
                 "@babel/eslint-parser": "^7.25.1",
@@ -25,11 +25,12 @@
                 "eslint": "^9.10.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-prettier": "^5.2.1",
+                "npm-check-updates": "^17.1.1",
                 "prettier": "3.3.3",
                 "rimraf": "^6.0.1",
-                "rollup": "^4.21.2",
-                "typescript": "^5.5.4",
-                "typescript-eslint": "^8.4.0"
+                "rollup": "^4.21.3",
+                "typescript": "^5.6.2",
+                "typescript-eslint": "^8.5.0"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -2366,14 +2367,15 @@
             }
         },
         "node_modules/@nextui-org/button": {
-            "version": "2.0.37",
-            "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.37.tgz",
-            "integrity": "sha512-dBtdO30qfu+K4YYLNmmpUy16Q82H1ucY8A4NjP4iEAJ1sPunoAYvba7h9xabrpUKW9IOyItOThSesxsfpaXYug==",
+            "version": "2.0.38",
+            "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.38.tgz",
+            "integrity": "sha512-XbgyqBv+X7QirXeriGwkqkMOENpAxXRo+jzfMyBMvfsM3kwrFj92OSF1F7/dWDvcW7imVZB9o2Ci7LIppq9ZZQ==",
+            "license": "MIT",
             "dependencies": {
-                "@nextui-org/react-utils": "2.0.16",
-                "@nextui-org/ripple": "2.0.32",
-                "@nextui-org/shared-utils": "2.0.7",
-                "@nextui-org/spinner": "2.0.33",
+                "@nextui-org/react-utils": "2.0.17",
+                "@nextui-org/ripple": "2.0.33",
+                "@nextui-org/shared-utils": "2.0.8",
+                "@nextui-org/spinner": "2.0.34",
                 "@nextui-org/use-aria-button": "2.0.10",
                 "@react-aria/button": "3.9.5",
                 "@react-aria/focus": "3.17.1",
@@ -2390,14 +2392,43 @@
                 "react-dom": ">=18"
             }
         },
-        "node_modules/@nextui-org/card": {
-            "version": "2.0.33",
-            "resolved": "https://registry.npmjs.org/@nextui-org/card/-/card-2.0.33.tgz",
-            "integrity": "sha512-iO/ThbUz75YlcFrWO9EssMhOxbc9LN0SSk181+2QnPDbKls9wbkUEfGjq/d9k3h6jb9FaR5N5XwVpT4aUt2Usw==",
+        "node_modules/@nextui-org/button/node_modules/@nextui-org/react-rsc-utils": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@nextui-org/react-rsc-utils/-/react-rsc-utils-2.0.14.tgz",
+            "integrity": "sha512-s0GVgDhScyx+d9FtXd8BXf049REyaPvWsO4RRr7JDHrk91NlQ11Mqxka9o+8g5NX0rphI0rbe3/b1Dz+iQRx3w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=18"
+            }
+        },
+        "node_modules/@nextui-org/button/node_modules/@nextui-org/react-utils": {
+            "version": "2.0.17",
+            "resolved": "https://registry.npmjs.org/@nextui-org/react-utils/-/react-utils-2.0.17.tgz",
+            "integrity": "sha512-U/b49hToVfhOM4dg4n57ZyUjLpts4JogQ139lfQBYPTb8z/ATNsJ3vLIqW5ZvDK6L0Er+JT11UVQ+03m7QMvaQ==",
+            "license": "MIT",
             "dependencies": {
-                "@nextui-org/react-utils": "2.0.16",
-                "@nextui-org/ripple": "2.0.32",
-                "@nextui-org/shared-utils": "2.0.7",
+                "@nextui-org/react-rsc-utils": "2.0.14",
+                "@nextui-org/shared-utils": "2.0.8"
+            },
+            "peerDependencies": {
+                "react": ">=18"
+            }
+        },
+        "node_modules/@nextui-org/button/node_modules/@nextui-org/shared-utils": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/@nextui-org/shared-utils/-/shared-utils-2.0.8.tgz",
+            "integrity": "sha512-ZEtoMPXS+IjT8GvpJTS9IWDnT1JNCKV+NDqqgysAf1niJmOFLyJgl6dh/9n4ufcGf1GbSEQN+VhJasEw7ajYGQ==",
+            "license": "MIT"
+        },
+        "node_modules/@nextui-org/card": {
+            "version": "2.0.34",
+            "resolved": "https://registry.npmjs.org/@nextui-org/card/-/card-2.0.34.tgz",
+            "integrity": "sha512-2RYNPsQkM0FOifGCKmRBR3AuYgYCNmPV7dyA5M3D9Lf0APsHHtsXRA/GeIJ/AuPnglZrYBX8wpM5kLt3dnlQjQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@nextui-org/react-utils": "2.0.17",
+                "@nextui-org/ripple": "2.0.33",
+                "@nextui-org/shared-utils": "2.0.8",
                 "@nextui-org/use-aria-button": "2.0.10",
                 "@react-aria/button": "3.9.5",
                 "@react-aria/focus": "3.17.1",
@@ -2413,15 +2444,45 @@
                 "react-dom": ">=18"
             }
         },
+        "node_modules/@nextui-org/card/node_modules/@nextui-org/react-rsc-utils": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@nextui-org/react-rsc-utils/-/react-rsc-utils-2.0.14.tgz",
+            "integrity": "sha512-s0GVgDhScyx+d9FtXd8BXf049REyaPvWsO4RRr7JDHrk91NlQ11Mqxka9o+8g5NX0rphI0rbe3/b1Dz+iQRx3w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=18"
+            }
+        },
+        "node_modules/@nextui-org/card/node_modules/@nextui-org/react-utils": {
+            "version": "2.0.17",
+            "resolved": "https://registry.npmjs.org/@nextui-org/react-utils/-/react-utils-2.0.17.tgz",
+            "integrity": "sha512-U/b49hToVfhOM4dg4n57ZyUjLpts4JogQ139lfQBYPTb8z/ATNsJ3vLIqW5ZvDK6L0Er+JT11UVQ+03m7QMvaQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@nextui-org/react-rsc-utils": "2.0.14",
+                "@nextui-org/shared-utils": "2.0.8"
+            },
+            "peerDependencies": {
+                "react": ">=18"
+            }
+        },
+        "node_modules/@nextui-org/card/node_modules/@nextui-org/shared-utils": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/@nextui-org/shared-utils/-/shared-utils-2.0.8.tgz",
+            "integrity": "sha512-ZEtoMPXS+IjT8GvpJTS9IWDnT1JNCKV+NDqqgysAf1niJmOFLyJgl6dh/9n4ufcGf1GbSEQN+VhJasEw7ajYGQ==",
+            "license": "MIT"
+        },
         "node_modules/@nextui-org/react-rsc-utils": {
             "version": "2.0.13",
             "resolved": "https://registry.npmjs.org/@nextui-org/react-rsc-utils/-/react-rsc-utils-2.0.13.tgz",
-            "integrity": "sha512-QewsXtoQlMsR9stThdazKEImg9oyZkPLs7wsymhrzh6/HdQCl9bTdb6tJcROg4vg5LRYKGG11USSQO2nKlfCcQ=="
+            "integrity": "sha512-QewsXtoQlMsR9stThdazKEImg9oyZkPLs7wsymhrzh6/HdQCl9bTdb6tJcROg4vg5LRYKGG11USSQO2nKlfCcQ==",
+            "peer": true
         },
         "node_modules/@nextui-org/react-utils": {
             "version": "2.0.16",
             "resolved": "https://registry.npmjs.org/@nextui-org/react-utils/-/react-utils-2.0.16.tgz",
             "integrity": "sha512-QdDoqzhx+4t9cDTVmtw5iOrfyLvpqyKsq8PARHUniCiQQDQd1ao7FCpzHgvU9poYcEdRk+Lsna66zbeMkFBB6w==",
+            "peer": true,
             "dependencies": {
                 "@nextui-org/react-rsc-utils": "2.0.13",
                 "@nextui-org/shared-utils": "2.0.7"
@@ -2431,12 +2492,13 @@
             }
         },
         "node_modules/@nextui-org/ripple": {
-            "version": "2.0.32",
-            "resolved": "https://registry.npmjs.org/@nextui-org/ripple/-/ripple-2.0.32.tgz",
-            "integrity": "sha512-xOqoHWzpvv5KRh7P8pXt3aZEmI1tyhiTNhrwjJaRME0d5xSA0gNzYhrjP5g0+Dxy4nKRDIZ1znJcd87KI07JFA==",
+            "version": "2.0.33",
+            "resolved": "https://registry.npmjs.org/@nextui-org/ripple/-/ripple-2.0.33.tgz",
+            "integrity": "sha512-Zsa60CXtGCF7weTCFbSfT0OlxlGHdd5b/sSJTYrmMZRHOIUpHW8kT0bxVYF/6X8nCCJYxzBKXUqdE3Y31fhNeQ==",
+            "license": "MIT",
             "dependencies": {
-                "@nextui-org/react-utils": "2.0.16",
-                "@nextui-org/shared-utils": "2.0.7"
+                "@nextui-org/react-utils": "2.0.17",
+                "@nextui-org/shared-utils": "2.0.8"
             },
             "peerDependencies": {
                 "@nextui-org/system": ">=2.0.0",
@@ -2446,24 +2508,96 @@
                 "react-dom": ">=18"
             }
         },
+        "node_modules/@nextui-org/ripple/node_modules/@nextui-org/react-rsc-utils": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@nextui-org/react-rsc-utils/-/react-rsc-utils-2.0.14.tgz",
+            "integrity": "sha512-s0GVgDhScyx+d9FtXd8BXf049REyaPvWsO4RRr7JDHrk91NlQ11Mqxka9o+8g5NX0rphI0rbe3/b1Dz+iQRx3w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=18"
+            }
+        },
+        "node_modules/@nextui-org/ripple/node_modules/@nextui-org/react-utils": {
+            "version": "2.0.17",
+            "resolved": "https://registry.npmjs.org/@nextui-org/react-utils/-/react-utils-2.0.17.tgz",
+            "integrity": "sha512-U/b49hToVfhOM4dg4n57ZyUjLpts4JogQ139lfQBYPTb8z/ATNsJ3vLIqW5ZvDK6L0Er+JT11UVQ+03m7QMvaQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@nextui-org/react-rsc-utils": "2.0.14",
+                "@nextui-org/shared-utils": "2.0.8"
+            },
+            "peerDependencies": {
+                "react": ">=18"
+            }
+        },
+        "node_modules/@nextui-org/ripple/node_modules/@nextui-org/shared-utils": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/@nextui-org/shared-utils/-/shared-utils-2.0.8.tgz",
+            "integrity": "sha512-ZEtoMPXS+IjT8GvpJTS9IWDnT1JNCKV+NDqqgysAf1niJmOFLyJgl6dh/9n4ufcGf1GbSEQN+VhJasEw7ajYGQ==",
+            "license": "MIT"
+        },
         "node_modules/@nextui-org/shared-utils": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@nextui-org/shared-utils/-/shared-utils-2.0.7.tgz",
-            "integrity": "sha512-FxY3N0i1Al7Oz3yOQN0dSpG8UUrLIP3iYh3ubD7BhdQoZLl5xbG6++q1gqOzZXV+ZWeUFMY/or0ofzWxGHiOow=="
+            "integrity": "sha512-FxY3N0i1Al7Oz3yOQN0dSpG8UUrLIP3iYh3ubD7BhdQoZLl5xbG6++q1gqOzZXV+ZWeUFMY/or0ofzWxGHiOow==",
+            "peer": true
         },
         "node_modules/@nextui-org/spinner": {
-            "version": "2.0.33",
-            "resolved": "https://registry.npmjs.org/@nextui-org/spinner/-/spinner-2.0.33.tgz",
-            "integrity": "sha512-c1wW4YEbzdn0t1MJAXhJ2W0PuNxrxtZg2DVqJeqh3180y4iQPYDzEy7oFoU0FpK53LcBPxjfsKHNL6v1pn+60A==",
+            "version": "2.0.34",
+            "resolved": "https://registry.npmjs.org/@nextui-org/spinner/-/spinner-2.0.34.tgz",
+            "integrity": "sha512-YKw/6xSLhsXU1k22OvYKyWhtJCHzW2bRAiieVSVG5xak3gYwknTds5H9s5uur+oAZVK9AkyAObD19QuZND32Jg==",
+            "license": "MIT",
             "dependencies": {
-                "@nextui-org/react-utils": "2.0.16",
-                "@nextui-org/shared-utils": "2.0.7",
-                "@nextui-org/system-rsc": "2.1.5"
+                "@nextui-org/react-utils": "2.0.17",
+                "@nextui-org/shared-utils": "2.0.8",
+                "@nextui-org/system-rsc": "2.1.6"
             },
             "peerDependencies": {
                 "@nextui-org/theme": ">=2.1.0",
                 "react": ">=18",
                 "react-dom": ">=18"
+            }
+        },
+        "node_modules/@nextui-org/spinner/node_modules/@nextui-org/react-rsc-utils": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@nextui-org/react-rsc-utils/-/react-rsc-utils-2.0.14.tgz",
+            "integrity": "sha512-s0GVgDhScyx+d9FtXd8BXf049REyaPvWsO4RRr7JDHrk91NlQ11Mqxka9o+8g5NX0rphI0rbe3/b1Dz+iQRx3w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=18"
+            }
+        },
+        "node_modules/@nextui-org/spinner/node_modules/@nextui-org/react-utils": {
+            "version": "2.0.17",
+            "resolved": "https://registry.npmjs.org/@nextui-org/react-utils/-/react-utils-2.0.17.tgz",
+            "integrity": "sha512-U/b49hToVfhOM4dg4n57ZyUjLpts4JogQ139lfQBYPTb8z/ATNsJ3vLIqW5ZvDK6L0Er+JT11UVQ+03m7QMvaQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@nextui-org/react-rsc-utils": "2.0.14",
+                "@nextui-org/shared-utils": "2.0.8"
+            },
+            "peerDependencies": {
+                "react": ">=18"
+            }
+        },
+        "node_modules/@nextui-org/spinner/node_modules/@nextui-org/shared-utils": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/@nextui-org/shared-utils/-/shared-utils-2.0.8.tgz",
+            "integrity": "sha512-ZEtoMPXS+IjT8GvpJTS9IWDnT1JNCKV+NDqqgysAf1niJmOFLyJgl6dh/9n4ufcGf1GbSEQN+VhJasEw7ajYGQ==",
+            "license": "MIT"
+        },
+        "node_modules/@nextui-org/spinner/node_modules/@nextui-org/system-rsc": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@nextui-org/system-rsc/-/system-rsc-2.1.6.tgz",
+            "integrity": "sha512-Wl2QwEFjYwuvw26R1RH3ZY81PD8YmfgtIjFvJZRP2VEIT6rPvlQ4ojgqdrkVkQZQ0L/K+5ZLbTKgLEFkj5ysdQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@react-types/shared": "3.23.1",
+                "clsx": "^1.2.1"
+            },
+            "peerDependencies": {
+                "@nextui-org/theme": ">=2.1.0",
+                "react": ">=18"
             }
         },
         "node_modules/@nextui-org/system": {
@@ -2491,6 +2625,7 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nextui-org/system-rsc/-/system-rsc-2.1.5.tgz",
             "integrity": "sha512-tkJLAyJu34Rr5KUMMqoB7cZjOVXB+7a/7N4ushZfuiLdoYijgmcXFMzLxjm+tbt9zA5AV+ivsfbHvscg77dJ6w==",
+            "peer": true,
             "dependencies": {
                 "@react-types/shared": "3.23.1",
                 "clsx": "^1.2.1"
@@ -3030,208 +3165,224 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.2.tgz",
-            "integrity": "sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.3.tgz",
+            "integrity": "sha512-MmKSfaB9GX+zXl6E8z4koOr/xU63AMVleLEa64v7R0QF/ZloMs5vcD1sHgM64GXXS1csaJutG+ddtzcueI/BLg==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.2.tgz",
-            "integrity": "sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.3.tgz",
+            "integrity": "sha512-zrt8ecH07PE3sB4jPOggweBjJMzI1JG5xI2DIsUbkA+7K+Gkjys6eV7i9pOenNSDJH3eOr/jLb/PzqtmdwDq5g==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.2.tgz",
-            "integrity": "sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.3.tgz",
+            "integrity": "sha512-P0UxIOrKNBFTQaXTxOH4RxuEBVCgEA5UTNV6Yz7z9QHnUJ7eLX9reOd/NYMO3+XZO2cco19mXTxDMXxit4R/eQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.2.tgz",
-            "integrity": "sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.3.tgz",
+            "integrity": "sha512-L1M0vKGO5ASKntqtsFEjTq/fD91vAqnzeaF6sfNAy55aD+Hi2pBI5DKwCO+UNDQHWsDViJLqshxOahXyLSh3EA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.2.tgz",
-            "integrity": "sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.3.tgz",
+            "integrity": "sha512-btVgIsCjuYFKUjopPoWiDqmoUXQDiW2A4C3Mtmp5vACm7/GnyuprqIDPNczeyR5W8rTXEbkmrJux7cJmD99D2g==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.2.tgz",
-            "integrity": "sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.3.tgz",
+            "integrity": "sha512-zmjbSphplZlau6ZTkxd3+NMtE4UKVy7U4aVFMmHcgO5CUbw17ZP6QCgyxhzGaU/wFFdTfiojjbLG3/0p9HhAqA==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.2.tgz",
-            "integrity": "sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.3.tgz",
+            "integrity": "sha512-nSZfcZtAnQPRZmUkUQwZq2OjQciR6tEoJaZVFvLHsj0MF6QhNMg0fQ6mUOsiCUpTqxTx0/O6gX0V/nYc7LrgPw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.2.tgz",
-            "integrity": "sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.3.tgz",
+            "integrity": "sha512-MnvSPGO8KJXIMGlQDYfvYS3IosFN2rKsvxRpPO2l2cum+Z3exiExLwVU+GExL96pn8IP+GdH8Tz70EpBhO0sIQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.2.tgz",
-            "integrity": "sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.3.tgz",
+            "integrity": "sha512-+W+p/9QNDr2vE2AXU0qIy0qQE75E8RTwTwgqS2G5CRQ11vzq0tbnfBd6brWhS9bCRjAjepJe2fvvkvS3dno+iw==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.2.tgz",
-            "integrity": "sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.3.tgz",
+            "integrity": "sha512-yXH6K6KfqGXaxHrtr+Uoy+JpNlUlI46BKVyonGiaD74ravdnF9BUNC+vV+SIuB96hUMGShhKV693rF9QDfO6nQ==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.2.tgz",
-            "integrity": "sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.3.tgz",
+            "integrity": "sha512-R8cwY9wcnApN/KDYWTH4gV/ypvy9yZUHlbJvfaiXSB48JO3KpwSpjOGqO4jnGkLDSk1hgjYkTbTt6Q7uvPf8eg==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.2.tgz",
-            "integrity": "sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.3.tgz",
+            "integrity": "sha512-kZPbX/NOPh0vhS5sI+dR8L1bU2cSO9FgxwM8r7wHzGydzfSjLRCFAT87GR5U9scj2rhzN3JPYVC7NoBbl4FZ0g==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.2.tgz",
-            "integrity": "sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.3.tgz",
+            "integrity": "sha512-S0Yq+xA1VEH66uiMNhijsWAafffydd2X5b77eLHfRmfLsRSpbiAWiRHV6DEpz6aOToPsgid7TI9rGd6zB1rhbg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.2.tgz",
-            "integrity": "sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.3.tgz",
+            "integrity": "sha512-9isNzeL34yquCPyerog+IMCNxKR8XYmGd0tHSV+OVx0TmE0aJOo9uw4fZfUuk2qxobP5sug6vNdZR6u7Mw7Q+Q==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.2.tgz",
-            "integrity": "sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.3.tgz",
+            "integrity": "sha512-nMIdKnfZfzn1Vsk+RuOvl43ONTZXoAPUUxgcU0tXooqg4YrAqzfKzVenqqk2g5efWh46/D28cKFrOzDSW28gTA==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.2.tgz",
-            "integrity": "sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.3.tgz",
+            "integrity": "sha512-fOvu7PCQjAj4eWDEuD8Xz5gpzFqXzGlxHZozHP4b9Jxv9APtdxL6STqztDzMLuRXEc4UpXGGhx029Xgm91QBeA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -3303,17 +3454,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.4.0.tgz",
-            "integrity": "sha512-rg8LGdv7ri3oAlenMACk9e+AR4wUV0yrrG+XKsGKOK0EVgeEDqurkXMPILG2836fW4ibokTB5v4b6Z9+GYQDEw==",
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.5.0.tgz",
+            "integrity": "sha512-lHS5hvz33iUFQKuPFGheAB84LwcJ60G8vKnEhnfcK1l8kGVLro2SFYW6K0/tj8FUhRJ0VHyg1oAfg50QGbPPHw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.4.0",
-                "@typescript-eslint/type-utils": "8.4.0",
-                "@typescript-eslint/utils": "8.4.0",
-                "@typescript-eslint/visitor-keys": "8.4.0",
+                "@typescript-eslint/scope-manager": "8.5.0",
+                "@typescript-eslint/type-utils": "8.5.0",
+                "@typescript-eslint/utils": "8.5.0",
+                "@typescript-eslint/visitor-keys": "8.5.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -3337,16 +3488,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.4.0.tgz",
-            "integrity": "sha512-NHgWmKSgJk5K9N16GIhQ4jSobBoJwrmURaLErad0qlLjrpP5bECYg+wxVTGlGZmJbU03jj/dfnb6V9bw+5icsA==",
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.5.0.tgz",
+            "integrity": "sha512-gF77eNv0Xz2UJg/NbpWJ0kqAm35UMsvZf1GHj8D9MRFTj/V3tAciIWXfmPLsAAF/vUlpWPvUDyH1jjsr0cMVWw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.4.0",
-                "@typescript-eslint/types": "8.4.0",
-                "@typescript-eslint/typescript-estree": "8.4.0",
-                "@typescript-eslint/visitor-keys": "8.4.0",
+                "@typescript-eslint/scope-manager": "8.5.0",
+                "@typescript-eslint/types": "8.5.0",
+                "@typescript-eslint/typescript-estree": "8.5.0",
+                "@typescript-eslint/visitor-keys": "8.5.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -3366,14 +3517,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.4.0.tgz",
-            "integrity": "sha512-n2jFxLeY0JmKfUqy3P70rs6vdoPjHK8P/w+zJcV3fk0b0BwRXC/zxRTEnAsgYT7MwdQDt/ZEbtdzdVC+hcpF0A==",
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.5.0.tgz",
+            "integrity": "sha512-06JOQ9Qgj33yvBEx6tpC8ecP9o860rsR22hWMEd12WcTRrfaFgHr2RB/CA/B+7BMhHkXT4chg2MyboGdFGawYg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.4.0",
-                "@typescript-eslint/visitor-keys": "8.4.0"
+                "@typescript-eslint/types": "8.5.0",
+                "@typescript-eslint/visitor-keys": "8.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3384,14 +3535,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.4.0.tgz",
-            "integrity": "sha512-pu2PAmNrl9KX6TtirVOrbLPLwDmASpZhK/XU7WvoKoCUkdtq9zF7qQ7gna0GBZFN0hci0vHaSusiL2WpsQk37A==",
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.5.0.tgz",
+            "integrity": "sha512-N1K8Ix+lUM+cIDhL2uekVn/ZD7TZW+9/rwz8DclQpcQ9rk4sIL5CAlBC0CugWKREmDjBzI/kQqU4wkg46jWLYA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.4.0",
-                "@typescript-eslint/utils": "8.4.0",
+                "@typescript-eslint/typescript-estree": "8.5.0",
+                "@typescript-eslint/utils": "8.5.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             },
@@ -3409,9 +3560,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.4.0.tgz",
-            "integrity": "sha512-T1RB3KQdskh9t3v/qv7niK6P8yvn7ja1mS7QK7XfRVL6wtZ8/mFs/FHf4fKvTA0rKnqnYxl/uHFNbnEt0phgbw==",
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.5.0.tgz",
+            "integrity": "sha512-qjkormnQS5wF9pjSi6q60bKUHH44j2APxfh9TQRXK8wbYVeDYYdYJGIROL87LGZZ2gz3Rbmjc736qyL8deVtdw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3423,14 +3574,14 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.4.0.tgz",
-            "integrity": "sha512-kJ2OIP4dQw5gdI4uXsaxUZHRwWAGpREJ9Zq6D5L0BweyOrWsL6Sz0YcAZGWhvKnH7fm1J5YFE1JrQL0c9dd53A==",
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.5.0.tgz",
+            "integrity": "sha512-vEG2Sf9P8BPQ+d0pxdfndw3xIXaoSjliG0/Ejk7UggByZPKXmJmw3GW5jV2gHNQNawBUyfahoSiCFVov0Ruf7Q==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/types": "8.4.0",
-                "@typescript-eslint/visitor-keys": "8.4.0",
+                "@typescript-eslint/types": "8.5.0",
+                "@typescript-eslint/visitor-keys": "8.5.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -3452,16 +3603,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.4.0.tgz",
-            "integrity": "sha512-swULW8n1IKLjRAgciCkTCafyTHHfwVQFt8DovmaF69sKbOxTSFMmIZaSHjqO9i/RV0wIblaawhzvtva8Nmm7lQ==",
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.5.0.tgz",
+            "integrity": "sha512-6yyGYVL0e+VzGYp60wvkBHiqDWOpT63pdMV2CVG4LVDd5uR6q1qQN/7LafBZtAtNIn/mqXjsSeS5ggv/P0iECw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.4.0",
-                "@typescript-eslint/types": "8.4.0",
-                "@typescript-eslint/typescript-estree": "8.4.0"
+                "@typescript-eslint/scope-manager": "8.5.0",
+                "@typescript-eslint/types": "8.5.0",
+                "@typescript-eslint/typescript-estree": "8.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3475,13 +3626,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.4.0.tgz",
-            "integrity": "sha512-zTQD6WLNTre1hj5wp09nBIDiOc2U5r/qmzo7wxPn4ZgAjHql09EofqhF9WF+fZHzL5aCyaIpPcT2hyxl73kr9A==",
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.5.0.tgz",
+            "integrity": "sha512-yTPqMnbAZJNy2Xq2XU8AdtOW9tJIr+UQb64aXB9f3B1498Zx9JorVgFJcZpEc9UBuCCrdzKID2RGAMkYcDtZOw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.4.0",
+                "@typescript-eslint/types": "8.5.0",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
@@ -4912,9 +5063,10 @@
             "peer": true
         },
         "node_modules/lucide-react": {
-            "version": "0.439.0",
-            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.439.0.tgz",
-            "integrity": "sha512-PafSWvDTpxdtNEndS2HIHxcNAbd54OaqSYJO90/b63rab2HWYqDbH194j0i82ZFdWOAcf0AHinRykXRRK2PJbw==",
+            "version": "0.441.0",
+            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.441.0.tgz",
+            "integrity": "sha512-0vfExYtvSDhkC2lqg0zYVW1Uu9GsI4knuV9GP9by5z0Xhc4Zi5RejTxfz9LsjRmCyWVzHCJvxGKZWcRyvQCWVg==",
+            "license": "ISC",
             "peerDependencies": {
                 "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
             }
@@ -5018,6 +5170,21 @@
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm-check-updates": {
+            "version": "17.1.1",
+            "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.1.tgz",
+            "integrity": "sha512-2aqIzGAEWB7xPf0hKHTkNmUM5jHbn2S5r2/z/7dA5Ij2h/sVYAg9R/uVkaUC3VORPAfBm7pKkCWo6E9clEVQ9A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "ncu": "build/cli.js",
+                "npm-check-updates": "build/cli.js"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0",
+                "npm": ">=8.12.1"
             }
         },
         "node_modules/object-assign": {
@@ -5672,9 +5839,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.2.tgz",
-            "integrity": "sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==",
+            "version": "4.21.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.3.tgz",
+            "integrity": "sha512-7sqRtBNnEbcBtMeRVc6VRsJMmpI+JU1z9VTvW8D4gXIYQFz0aLcsE6rRkyghZkLfEgUZgVvOG7A5CVz/VW5GIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5688,22 +5855,22 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.21.2",
-                "@rollup/rollup-android-arm64": "4.21.2",
-                "@rollup/rollup-darwin-arm64": "4.21.2",
-                "@rollup/rollup-darwin-x64": "4.21.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.21.2",
-                "@rollup/rollup-linux-arm-musleabihf": "4.21.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.21.2",
-                "@rollup/rollup-linux-arm64-musl": "4.21.2",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.21.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.21.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.21.2",
-                "@rollup/rollup-linux-x64-gnu": "4.21.2",
-                "@rollup/rollup-linux-x64-musl": "4.21.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.21.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.21.2",
-                "@rollup/rollup-win32-x64-msvc": "4.21.2",
+                "@rollup/rollup-android-arm-eabi": "4.21.3",
+                "@rollup/rollup-android-arm64": "4.21.3",
+                "@rollup/rollup-darwin-arm64": "4.21.3",
+                "@rollup/rollup-darwin-x64": "4.21.3",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.21.3",
+                "@rollup/rollup-linux-arm-musleabihf": "4.21.3",
+                "@rollup/rollup-linux-arm64-gnu": "4.21.3",
+                "@rollup/rollup-linux-arm64-musl": "4.21.3",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.21.3",
+                "@rollup/rollup-linux-riscv64-gnu": "4.21.3",
+                "@rollup/rollup-linux-s390x-gnu": "4.21.3",
+                "@rollup/rollup-linux-x64-gnu": "4.21.3",
+                "@rollup/rollup-linux-x64-musl": "4.21.3",
+                "@rollup/rollup-win32-arm64-msvc": "4.21.3",
+                "@rollup/rollup-win32-ia32-msvc": "4.21.3",
+                "@rollup/rollup-win32-x64-msvc": "4.21.3",
                 "fsevents": "~2.3.2"
             }
         },
@@ -6198,9 +6365,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+            "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -6212,15 +6379,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.4.0.tgz",
-            "integrity": "sha512-67qoc3zQZe3CAkO0ua17+7aCLI0dU+sSQd1eKPGq06QE4rfQjstVXR6woHO5qQvGUa550NfGckT4tzh3b3c8Pw==",
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.5.0.tgz",
+            "integrity": "sha512-uD+XxEoSIvqtm4KE97etm32Tn5MfaZWgWfMMREStLxR6JzvHkc2Tkj7zhTEK5XmtpTmKHNnG8Sot6qDfhHtR1Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.4.0",
-                "@typescript-eslint/parser": "8.4.0",
-                "@typescript-eslint/utils": "8.4.0"
+                "@typescript-eslint/eslint-plugin": "8.5.0",
+                "@typescript-eslint/parser": "8.5.0",
+                "@typescript-eslint/utils": "8.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -30,12 +30,16 @@
         "build": "rollup -c --minifyInternalExports true --treeshake smallest",
         "clean": "rimraf dist/* --glob",
         "lint": "tsc && eslint",
-        "lint:fix": "eslint --fix"
+        "lint:fix": "eslint --fix",
+        "check:update": "ncu",
+        "update": "ncu -u -t patch && npm install",
+        "update:minor": "ncu -u -t minor && npm install",
+        "update:major": "ncu -u && npm install"
     },
     "dependencies": {
-        "@nextui-org/button": "^2.0.37",
-        "@nextui-org/card": "^2.0.33",
-        "lucide-react": "^0.439.0"
+        "@nextui-org/button": "^2.0.38",
+        "@nextui-org/card": "^2.0.34",
+        "lucide-react": "^0.441.0"
     },
     "devDependencies": {
         "@babel/eslint-parser": "^7.25.1",
@@ -49,10 +53,11 @@
         "eslint": "^9.10.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
+        "npm-check-updates": "^17.1.1",
         "prettier": "3.3.3",
         "rimraf": "^6.0.1",
-        "rollup": "^4.21.2",
-        "typescript": "^5.5.4",
-        "typescript-eslint": "^8.4.0"
+        "rollup": "^4.21.3",
+        "typescript": "^5.6.2",
+        "typescript-eslint": "^8.5.0"
     }
 }


### PR DESCRIPTION
This pull request adds check update scripts and updates the dependencies. The `registry-url` in the `.github/workflows/publish.yml` file is changed to `https://npm.pkg.github.com/`. The `package.json` file is updated with new versions of `@nextui-org/button`, `@nextui-org/card`, and `lucide-react`. Additionally, the dev dependencies `npm-check-updates`, `rollup`, `typescript`, and `typescript-eslint` are updated to their latest versions.

close #20