### PR TITLE
Fix lint workflow to trigger on push to main branch

### DIFF
--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -1,7 +1,7 @@
-name: Fix Code Style
+name: 
 
 on:
-    pull_request:
+    push:
         branches:
             - main
 
@@ -30,5 +30,10 @@ jobs:
             # - name: Test
             #   run: npm run test
 
-            - name: Build
-              run: npm run build
+            - name: Clean and Build
+              run: npm run clean && npm run build
+
+            - name: Commit builded files if any
+              uses: stefanzweifel/git-auto-commit-action@v5
+              with:
+                  commit_message: 'Auto build files'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,6 @@ jobs:
                   node-version: '20.x'
                   registry-url: 'https://registry.npmjs.org'
 
-            - run: npm ci --omit=dev
-            - run: npm run build
             - run: npm publish --provenance --access public
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request fixes the lint workflow to trigger on push to the main branch. Previously, the workflow was not triggering on push events, causing linting errors to go unnoticed. With this fix, the workflow will now properly trigger on push events to the main branch, ensuring that linting errors are caught and fixed in a timely manner.